### PR TITLE
Updated annotation messaging to use patching after initial DOM push

### DIFF
--- a/extension/sidebar/sidebar.js
+++ b/extension/sidebar/sidebar.js
@@ -1,5 +1,5 @@
 // Storage interface
-var storage = {
+const storage = {
   // Make sure storage is initialized to defaults
   init: function() {
     // Default settings. Initialize storage to these values.
@@ -14,7 +14,7 @@ var storage = {
 }
 
 // Page-specific logic
-var app = {
+const app = {
   init: function(storage) {
     const taggingToggle = document.getElementById('taggingActive');
     var state = {
@@ -73,6 +73,8 @@ var app = {
             user_id: authToken,
             url: msg.data.url,
             html: msg.data.html,
+            selector: msg.data.selector,
+            domseg_class: msg.data.domseg_class
           }
         });
         oReq.send(body);    
@@ -120,7 +122,7 @@ var app = {
       });
     }
 
-    // Update class slectors with a new set of segment types
+    // Update class selectors with a new set of segment types
     function updateClassSelectors(segment_types) {
       class_selectors = document.getElementById('class-selectors');
 

--- a/server/lib/domsegserver/datasets.ex
+++ b/server/lib/domsegserver/datasets.ex
@@ -122,8 +122,7 @@ defmodule DOMSegServer.Datasets do
     num_users = Repo.aggregate(query, :count)
 
     query = from s in ds_query, select: fragment("avg(length(?))", s.html)
-    avg_html_len = Repo.one(query) |> IO.inspect()
-
+    avg_html_len = Repo.one(query)
 
     %{
       num_urls: num_urls,

--- a/server/lib/domsegserver_web/controllers/sample_controller.ex
+++ b/server/lib/domsegserver_web/controllers/sample_controller.ex
@@ -7,7 +7,34 @@ defmodule DOMSegServerWeb.SampleController do
 
   action_fallback DOMSegServerWeb.FallbackController
 
+  def upsert(conn, %{"sample" => %{"html" => html} = sample_params} = data) when is_nil(html) do
+    IO.puts("upsert-patching")
+    keys = Samples.extract_keys(sample_params) |> IO.inspect(label: "keys")
+    domseg_class = sample_params["domseg_class"] |> IO.inspect(label: "domseg_class")
+    selector = sample_params["selector"] |> IO.inspect(label: "selector")
+
+    with(
+      %Sample{} = sample <- Samples.get_sample(keys),
+      {:ok, document} <- Floki.parse_document(sample.html),
+      patched_doc <- patch_document(document, selector, domseg_class),
+      patched_html <- Floki.raw_html(patched_doc),
+      {:ok, %Sample{} = sample} <- Samples.upsert_sample(keys, %{sample_params | "html" => patched_html})
+    ) do
+        conn
+        |> put_status(:ok)
+        |> render("show.json", sample: sample)
+    else
+      err ->
+        IO.inspect(err, label: "err")
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(ErrorView)
+        |> render("422.json", data)
+    end
+  end
+
   def upsert(conn, %{"sample" => sample_params} = data) do
+    IO.puts("upsert-creating")
     keys = Samples.extract_keys(sample_params)
     with {:ok, %Sample{} = sample} <- Samples.upsert_sample(keys, sample_params) do
       conn
@@ -20,5 +47,10 @@ defmodule DOMSegServerWeb.SampleController do
         |> put_view(ErrorView)
         |> render("422.json", data)
     end
+  end
+
+  defp patch_document(document, selector, domseg_class) do
+    # Floki.find(document, selector) |> IO.inspect(label: "patch_document matches")
+    Floki.attr(document, selector, "data-domseg-class", fn (_) -> domseg_class end)
   end
 end

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -41,7 +41,7 @@ defmodule DOMSegServer.MixProject do
       {:phoenix_html, "~> 3.0"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:phoenix_live_view, "~> 0.16.0"},
-      {:floki, ">= 0.30.0", only: :test},
+      {:floki, ">= 0.30.0"},
       {:phoenix_live_dashboard, "~> 0.5"},
       {:esbuild, "~> 0.2", runtime: Mix.env() == :dev},
       {:swoosh, "~> 1.3"},

--- a/server/priv/dev/DOMSegServer.postman_collection.json
+++ b/server/priv/dev/DOMSegServer.postman_collection.json
@@ -30,7 +30,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "localhost:4000/api/datasets/8ba17003-d0d9-4add-8eb8-1ad3b0cc52b6",
+					"raw": "localhost:4000/api/datasets/c9932b60-90ed-4111-9210-777dc2dfbf3b",
 					"host": [
 						"localhost"
 					],
@@ -38,7 +38,7 @@
 					"path": [
 						"api",
 						"datasets",
-						"8ba17003-d0d9-4add-8eb8-1ad3b0cc52b6"
+						"c9932b60-90ed-4111-9210-777dc2dfbf3b"
 					]
 				}
 			},
@@ -51,7 +51,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"sample\": {\n    \"user_id\": \"11cdcd44-cf5e-46e4-8f9d-301422a9340d\",\n    \"dataset_id\": \"8ba17003-d0d9-4add-8eb8-1ad3b0cc52b6\",\n    \"url\": \"http://foo.com\",\n    \"html\": \"text\"\n  }\n}",
+					"raw": "{\n    \"sample\": {\n        \"dataset_id\": \"c9932b60-90ed-4111-9210-777dc2dfbf3b\", \n        \"domseg_class\": \"content\", \n        \"html\": null, \n        \"selector\": \"html > body > div:nth-child(3) > #content > div:nth-child(3) > div:nth-child(6) > div > div:nth-child(4)\", \n        \"url\": \"https://stackoverflow.com/company/press\", \n        \"user_id\": \"ccc159ed-9e7b-4dd2-9d3c-f5c9f7cad167\"\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -67,64 +67,6 @@
 					"path": [
 						"api",
 						"samples"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "localhost:4000/api/samples/:id",
-			"request": {
-				"method": "PATCH",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"sample\": {\n    \"html\": \"text_patch\"\n  }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "localhost:4000/api/samples/06e70b76-a4d1-4ced-8cd4-bc00bb37cc86",
-					"host": [
-						"localhost"
-					],
-					"port": "4000",
-					"path": [
-						"api",
-						"samples",
-						"06e70b76-a4d1-4ced-8cd4-bc00bb37cc86"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "localhost:4000/api/samples/:id Copy",
-			"request": {
-				"method": "PUT",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"sample\": {\n    \"html\": \"text_put\"\n  }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "localhost:4000/api/samples/06e70b76-a4d1-4ced-8cd4-bc00bb37cc86",
-					"host": [
-						"localhost"
-					],
-					"port": "4000",
-					"path": [
-						"api",
-						"samples",
-						"06e70b76-a4d1-4ced-8cd4-bc00bb37cc86"
 					]
 				}
 			},


### PR DESCRIPTION
Closes #7.  Prior code was pushing the entire DOM on every tag event, new code pushes entire DOM on first tag event and CSS-selector-based patches afterward.